### PR TITLE
Version 1.2

### DIFF
--- a/TemporaryAlert.podspec
+++ b/TemporaryAlert.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "TemporaryAlert"
-  s.version      = "1.1.0"
+  s.version      = "1.2.0"
   s.summary      = "Temporary alerts similar to those in Apple's Music app."
   s.homepage     = "https://github.com/daniel-barros/TemporaryAlert"
   s.license      = { :type => "MIT", :file => "LICENSE.md" }

--- a/TemporaryAlert/TemporaryAlert.swift
+++ b/TemporaryAlert/TemporaryAlert.swift
@@ -25,7 +25,7 @@
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
- */
+*/
 
 
 import UIKit
@@ -38,15 +38,18 @@ public struct TemporaryAlert {
     public enum AlertImage {
         case checkmark, cross, custom(UIView)
     }
-    
+
     public enum Configuration {
         /// The color used to draw the default alert images. This does not apply if you provide a custom image.
         ///
         /// By default this is the same as `titleColor`.
-        public static var imageColor = #colorLiteral(red: 0.3450980392, green: 0.3450980392, blue: 0.3450980392, alpha: 1)
+        
+        public static var imageColor:Any? = [UIColor.darkGray, UIColor.lightGray]
         public static var backgroundColor = #colorLiteral(red: 0.9529411765, green: 0.9529411765, blue: 0.9529411765, alpha: 0.8)
-        public static var titleColor = #colorLiteral(red: 0.3450980392, green: 0.3450980392, blue: 0.3450980392, alpha: 1)
-        public static var messageColor = #colorLiteral(red: 0.6274509804, green: 0.6274509804, blue: 0.6274509804, alpha: 1)
+        public static var blurEnabled = true
+        public static var blurStyle: UIBlurEffect.Style = .light
+        public static var titleColor:Any? = [UIColor.darkGray, UIColor.lightGray]
+        public static var messageColor:Any? = [UIColor.lightGray, UIColor.lightText]
         public static var titleFont = UIFont.systemFont(ofSize: 22, weight: .semibold)
         public static var messageFont = UIFont.systemFont(ofSize: 16, weight: .semibold)
         /// The number of seconds alerts are visible.
@@ -60,6 +63,7 @@ public struct TemporaryAlert {
     // An independent window makes sure the alert is shown above everything else.
     fileprivate static var window: UIWindow?
     
+
     /// Shows an alert with the specified image, title and message.
     ///
     /// If you want to change the alert life span or customize the alert appearance use the variables in `TemporaryAlert.Configuration`.
@@ -84,7 +88,7 @@ public struct TemporaryAlert {
 // MARK: - Helpers
 
 fileprivate extension TemporaryAlert {
-    
+
     static func alertWindow() -> UIWindow {
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.windowLevel = UIWindow.Level(rawValue: CGFloat.greatestFiniteMagnitude)
@@ -92,5 +96,5 @@ fileprivate extension TemporaryAlert {
         window.isHidden = false
         window.isUserInteractionEnabled = false
         return window
-    }
+    }    
 }

--- a/TemporaryAlert/TemporaryAlert.swift
+++ b/TemporaryAlert/TemporaryAlert.swift
@@ -25,7 +25,7 @@
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
-*/
+ */
 
 
 import UIKit
@@ -84,13 +84,13 @@ public struct TemporaryAlert {
 // MARK: - Helpers
 
 fileprivate extension TemporaryAlert {
-
+    
     static func alertWindow() -> UIWindow {
         let window = UIWindow(frame: UIScreen.main.bounds)
-        window.windowLevel = .greatestFiniteMagnitude
+        window.windowLevel = UIWindow.Level(rawValue: CGFloat.greatestFiniteMagnitude)
         window.backgroundColor = nil
         window.isHidden = false
         window.isUserInteractionEnabled = false
         return window
-    }    
+    }
 }

--- a/TemporaryAlert/TemporaryAlertViewController.swift
+++ b/TemporaryAlert/TemporaryAlertViewController.swift
@@ -35,7 +35,7 @@ internal class TemporaryAlertViewController: UIViewController {
     var alertView: UIView
     fileprivate var imageLayer: CAShapeLayer?
     fileprivate var animatesImage = false
-
+    
     init(image: TemporaryAlert.AlertImage?, title: String, message: String?) {
         alertView = UIView()
         super.init(nibName: nil, bundle: nil)
@@ -75,18 +75,18 @@ internal class TemporaryAlertViewController: UIViewController {
                        usingSpringWithDamping: 1, initialSpringVelocity: 0,
                        options: .curveEaseOut,
                        animations: {
-                            self.alertView.transform = .identity
-                            self.alertView.alpha = 1
+                        self.alertView.transform = .identity
+                        self.alertView.alpha = 1
         },
                        completion: { _ in
-                            if self.animatesImage {
-                                self.imageLayer?.isHidden = false
-                                let animation = CABasicAnimation(keyPath:"strokeEnd")
-                                animation.duration = 0.2
-                                animation.fromValue = NSNumber(floatLiteral: 0)
-                                animation.toValue = NSNumber(floatLiteral: 1)
-                                self.imageLayer?.add(animation, forKey:"strokeEnd")
-                            }
+                        if self.animatesImage {
+                            self.imageLayer?.isHidden = false
+                            let animation = CABasicAnimation(keyPath:"strokeEnd")
+                            animation.duration = 0.2
+                            animation.fromValue = NSNumber(floatLiteral: 0)
+                            animation.toValue = NSNumber(floatLiteral: 1)
+                            self.imageLayer?.add(animation, forKey:"strokeEnd")
+                        }
         })
     }
     
@@ -96,8 +96,8 @@ internal class TemporaryAlertViewController: UIViewController {
                        usingSpringWithDamping: 1, initialSpringVelocity: 0,
                        options: .curveEaseIn,
                        animations: {
-                            self.alertView.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
-                            self.alertView.alpha = 0
+                        self.alertView.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+                        self.alertView.alpha = 0
         },
                        completion: completion)
     }
@@ -257,8 +257,8 @@ fileprivate extension TemporaryAlertViewController {
         layer.strokeColor = Configuration.imageColor.cgColor
         layer.fillColor = nil
         layer.lineWidth = 9
-        layer.lineJoin = kCALineJoinRound
-        layer.lineCap = kCALineCapRound
+        layer.lineJoin = CAShapeLayerLineJoin.round
+        layer.lineCap = CAShapeLayerLineCap.round
         view.layer.addSublayer(layer)
         imageLayer = layer
         return view

--- a/TemporaryAlert/TemporaryAlertViewController.swift
+++ b/TemporaryAlert/TemporaryAlertViewController.swift
@@ -35,7 +35,7 @@ internal class TemporaryAlertViewController: UIViewController {
     var alertView: UIView
     fileprivate var imageLayer: CAShapeLayer?
     fileprivate var animatesImage = false
-    
+
     init(image: TemporaryAlert.AlertImage?, title: String, message: String?) {
         alertView = UIView()
         super.init(nibName: nil, bundle: nil)
@@ -75,18 +75,18 @@ internal class TemporaryAlertViewController: UIViewController {
                        usingSpringWithDamping: 1, initialSpringVelocity: 0,
                        options: .curveEaseOut,
                        animations: {
-                        self.alertView.transform = .identity
-                        self.alertView.alpha = 1
+                            self.alertView.transform = .identity
+                            self.alertView.alpha = 1
         },
                        completion: { _ in
-                        if self.animatesImage {
-                            self.imageLayer?.isHidden = false
-                            let animation = CABasicAnimation(keyPath:"strokeEnd")
-                            animation.duration = 0.2
-                            animation.fromValue = NSNumber(floatLiteral: 0)
-                            animation.toValue = NSNumber(floatLiteral: 1)
-                            self.imageLayer?.add(animation, forKey:"strokeEnd")
-                        }
+                            if self.animatesImage {
+                                self.imageLayer?.isHidden = false
+                                let animation = CABasicAnimation(keyPath:"strokeEnd")
+                                animation.duration = 0.2
+                                animation.fromValue = NSNumber(floatLiteral: 0)
+                                animation.toValue = NSNumber(floatLiteral: 1)
+                                self.imageLayer?.add(animation, forKey:"strokeEnd")
+                            }
         })
     }
     
@@ -96,8 +96,8 @@ internal class TemporaryAlertViewController: UIViewController {
                        usingSpringWithDamping: 1, initialSpringVelocity: 0,
                        options: .curveEaseIn,
                        animations: {
-                        self.alertView.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
-                        self.alertView.alpha = 0
+                            self.alertView.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+                            self.alertView.alpha = 0
         },
                        completion: completion)
     }
@@ -198,11 +198,11 @@ fileprivate extension TemporaryAlertViewController {
     // MARK: -
     
     private func backgroundView() -> UIVisualEffectView {
-        let view = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+        let view = UIVisualEffectView(effect: UIBlurEffect(style: Configuration.blurStyle))
         view.frame = CGRect(x: 0, y: 0,
                             width: .alertViewWidth,
                             height: .alertViewMinHeight)
-        view.backgroundColor = Configuration.backgroundColor
+        view.backgroundColor = Configuration.blurEnabled ? UIColor.clear : Configuration.backgroundColor
         view.isUserInteractionEnabled = false
         view.layer.cornerRadius = 8
         view.layer.masksToBounds = true
@@ -215,7 +215,7 @@ fileprivate extension TemporaryAlertViewController {
         let label = UILabel()
         label.text = title
         label.font = Configuration.titleFont
-        label.textColor = Configuration.titleColor
+        label.textColor = getColor(Configuration.titleColor)
         label.numberOfLines = 0
         label.textAlignment = .center
         return label
@@ -226,7 +226,7 @@ fileprivate extension TemporaryAlertViewController {
         let label = UILabel()
         label.text = message
         label.font = Configuration.messageFont
-        label.textColor = Configuration.messageColor
+        label.textColor = getColor(Configuration.messageColor)
         label.numberOfLines = 0
         label.textAlignment = .center
         return label
@@ -254,7 +254,8 @@ fileprivate extension TemporaryAlertViewController {
         let layer = CAShapeLayer()
         layer.path = path.cgPath
         layer.position = position
-        layer.strokeColor = Configuration.imageColor.cgColor
+        layer.strokeColor = getColor(Configuration.imageColor)?.cgColor
+        //layer.strokeColor = Configuration.imageColor.cgColor
         layer.fillColor = nil
         layer.lineWidth = 9
         layer.lineJoin = CAShapeLayerLineJoin.round
@@ -264,6 +265,17 @@ fileprivate extension TemporaryAlertViewController {
         return view
     }
     
+    private func getColor<T>(_ color: T) -> UIColor? {
+        if let colors = color as? [UIColor], colors.count == 2 {
+            if Configuration.blurEnabled {
+                return Configuration.blurStyle == .light ? colors[0] : colors[1]
+            }
+            return colors[0]
+        }
+        else {
+            return color as? UIColor
+        }
+    }
     
     private func checkmarkPath(with size: CGSize) -> UIBezierPath {
         let path = UIBezierPath()


### PR DESCRIPTION
Syntax fix for Swift 4.2 and main feature - dark theme

`TemporaryAlert.Configuration.blurStyle = .dark`
![](https://i.imgur.com/H44MKDO.jpg)
` TemporaryAlert.Configuration.blurStyle = .light`
![](https://i.imgur.com/zKq8T0U.jpg)

![](https://i.imgur.com/Zv0ODkn.jpg)
`TemporaryAlert.Configuration.blurEnabled = false`
![](https://i.imgur.com/V5AKwtr.jpg)
